### PR TITLE
Upgrade from .NET 8 to .NET 10 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
     
     - name: Restore dependencies
       run: dotnet restore CRMAsyncHealthChecker.sln

--- a/CRMAsynHealthCheckerTests/CRMAsynHealthCheckerTests.csproj
+++ b/CRMAsynHealthCheckerTests/CRMAsynHealthCheckerTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>CRMAsynHealthCheckerTests</RootNamespace>
     <AssemblyName>CRMAsynHealthCheckerTests</AssemblyName>
     <IsPackable>false</IsPackable>

--- a/CRMAsyncHealthChecker/CRMAsyncHealthChecker.csproj
+++ b/CRMAsyncHealthChecker/CRMAsyncHealthChecker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>CRMAsyncHealthChecker</RootNamespace>
     <AssemblyName>CRMAsyncHealthChecker</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
Bumps TargetFramework net8.0 → net10.0 and CI dotnet-version 8.0.x → 10.0.x.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
